### PR TITLE
add credit tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Coming eventually
 
 `allowUserUploads` can be set to allow/block user uploaded tracks
 
-`artistSeperator` can be set to null to use only main artist
+`tagSeperator` the seperator used when adding multiple values to the same metadata tag (eg. artists)
 
 `coverFilename` can be set to null to delete jpg after embedding
 

--- a/src/default.config.json
+++ b/src/default.config.json
@@ -1,5 +1,5 @@
 {
-    "_version": 1,
+    "_version": 2,
     "albumDirectory": "./Downloads/{{albumArtist.name}}/{{album.title}} ({{releaseYear}})",
     "trackFilename": "{{artist.name}} - {{album.title}} - {{title}} - {{trackNumberPadded}}",
     "videoDirectory": "./Downloads/{{artist.name}}/{{title}} ({{releaseYear}})",
@@ -10,8 +10,8 @@
     "syncedLyricsOnly": false,
     "plainLyricsOnly": false,
     "embedMetadata": true,
-    "artistSeperator": "; ",
-    "useArtistsTag": true,
+    "tagSeperator": "; ",
+    "useArtistsTag": false,
     "allowUserUploads": false,
     "getCover": true,
     "coverFilename": "cover",

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ if (options.help || [
             syncedLyricsOnly: config.syncedLyricsOnly,
             plainLyricsOnly: config.plainLyricsOnly,
             useArtistsTag: config.useArtistsTag,
-            artistSeperator: config.artistSeperator,
+            tagSeperator: config.tagSeperator,
             customMetadata: config.customMetadata,
             keepContainerFile: config.debug ? true : false,
             segmentWaitMin: config.segmentWaitMin,

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -10,6 +10,7 @@ const embedMetadata = require('./embedMetadata');
 const extractContainer = require('./extractContainer');
 const getLyrics = require('./getLyrics');
 const formatString = require('./formatString');
+const normalizeTag = require('./normalizeTag');
 
 class Download {
     playbackInfo;
@@ -38,7 +39,7 @@ class Download {
         this.syncedLyricsOnly = options.syncedLyricsOnly ?? false;
         this.plainLyricsOnly = options.plainLyricsOnly ?? false;
         this.useArtistsTag = options.useArtistsTag ?? true;
-        this.artistSeperator = options.artistSeperator;
+        this.tagSeperator = options.tagSeperator;
         this.customMetadata = options.customMetadata;
         this.keepContainerFile = options.keepContainerFile ?? false;
         this.segmentWaitMin = options.segmentWaitMin ?? 0;
@@ -120,13 +121,17 @@ class Download {
             this.log('Cover already downladed');
         }
 
+        const albumCredits = this.details.album.credits;
+        const trackCredits = this.details.album.trackCredits.find(({ track }) => track.id === this.details.id)?.credits;
+
+        // TODO: add more credit tags
         this.metadata = [
             ['title', this.details.title],
-            ['artist', (this.useArtistsTag || !this.artistSeperator) ? this.details.artist?.name : this.details.artists?.map(i => i.name).join(this.artistSeperator)],
-            ['artists', this.useArtistsTag ? this.artistSeperator ? this.details.artists?.map(i => i.name).join(this.artistSeperator) : this.details.artist?.name : null],
+            ['artist', normalizeTag(this.details.artists?.map(i => i.name), !this.useArtistsTag ? this.tagSeperator : null)],
+            ['artists', this.useArtistsTag ? normalizeTag(this.details.artists?.map(i => i.name), this.tagSeperator) : null],
             ['album', this.details.album?.title],
-            ['albumartist', (this.useArtistsTag || !this.artistSeperator) ? this.details.albumArtist?.name : this.details.albumArtists?.map(i => i.name).join(this.artistSeperator)],
-            ['albumartists', this.useArtistsTag ? this.artistSeperator ? this.details.albumArtists?.map(i => i.name).join(this.artistSeperator) : this.details.albumArtist?.name : null],
+            ['albumartist', normalizeTag(this.details.albumArtists?.map(i => i.name), !this.useArtistsTag ? this.tagSeperator : null)],
+            ['albumartists', this.useArtistsTag ? normalizeTag(this.details.albumArtists?.map(i => i.name), this.tagSeperator) : null],
             ['date', this.details.releaseDate],
             ['originalyear', this.details.releaseYear],
             ['tracktotal', this.details.album?.trackCount],
@@ -137,6 +142,28 @@ class Download {
             ['replaygain_album_peak', this.playbackInfo.albumPeakAmplitude],
             ['replaygain_track_gain', this.playbackInfo.trackReplayGain || this.details.track?.replayGain], // NOTE: details.track.replayGain is actually playbackInfo.albumReplayGain
             ['replaygain_track_peak', this.playbackInfo.trackPeakAmplitude || this.details.track?.peak],
+            ['producer', normalizeTag(trackCredits?.producer?.map(i => i.name))],
+            ['composer', normalizeTag(trackCredits?.composer?.map(i => i.name))],
+            ['engineer', normalizeTag(trackCredits?.engineer?.map(i => i.name))],
+            ['mastering_engineer', normalizeTag(trackCredits?.masteringEngineer?.map(i => i.name))],
+            ['mixing_engineer', normalizeTag(trackCredits?.mixingEngineer?.map(i => i.name))],
+            ['additional_engineer', normalizeTag(trackCredits?.additionalEngineer?.map(i => i.name))],
+            ['assistant_engineer', normalizeTag(trackCredits?.assistantEngineer?.map(i => i.name))],
+            ['recording_engineer', normalizeTag(trackCredits?.recordingEngineer?.map(i => i.name))],
+            ['publisher', normalizeTag(trackCredits?.publisher?.map(i => i.name))],
+            ['remixer', normalizeTag(trackCredits?.remixer?.map(i => i.name))],
+            ['mixer', normalizeTag(trackCredits?.mixer?.map(i => i.name))],
+            ['lyricist', normalizeTag(trackCredits?.lyricist?.map(i => i.name))],
+            ['guitar', normalizeTag(trackCredits?.guitar?.map(i => i.name))],
+            ['banjo', normalizeTag(trackCredits?.banjo?.map(i => i.name))],
+            ['keyboard', normalizeTag(trackCredits?.keyboard?.map(i => i.name))],
+            ['drums', normalizeTag(trackCredits?.drums?.map(i => i.name))],
+            ['piano', normalizeTag(trackCredits?.piano?.map(i => i.name))],
+            ['bass', normalizeTag(trackCredits?.bass?.map(i => i.name))],
+            ['whistle', normalizeTag(trackCredits?.whistle?.map(i => i.name))],
+            ['horn', normalizeTag(trackCredits?.horn?.map(i => i.name))],
+            ['strings', normalizeTag(trackCredits?.strings?.map(i => i.name))],
+            ['label', normalizeTag(albumCredits?.label?.map(i => i.name))],
             ['copyright', this.details.track?.copyright],
             ['barcode', this.details.album?.upc],
             ['isrc', this.details.track?.isrc],

--- a/src/utils/getAlbum.js
+++ b/src/utils/getAlbum.js
@@ -4,13 +4,15 @@ const parseAlbum = require('./parseAlbum');
 async function getAlbum(albumId) {
     return parseAlbum(
         await tidalApi('privatev1', `/albums/${albumId}`).then(({ json }) => json),
-        await tidalApi('privatev1', '/pages/album', { query: { albumId } }).then(({ json }) => {
+        await tidalApi('privatev1', '/pages/album', { query: { albumId } }).then(async ({ json }) => {
             const { album, description, credits, review } = json.rows[0].modules[0];
             const tracks = json.rows[1].modules[0].pagedList.items.filter(({ type }) => type === 'track').map(({ item }) => item); // Default limit seems to be 9999
+            const trackCredits = await tidalApi('privatev1', `/albums/${albumId}/items/credits?replace=true&includeContributors=true&offset=0&limit=100`).then(({ json }) => json.items.filter(item => item.type === 'track'));
             return {
                 ...album,
                 description,
                 credits,
+                trackCredits,
                 review,
                 tracks,
             };

--- a/src/utils/normalizeTag.js
+++ b/src/utils/normalizeTag.js
@@ -1,0 +1,12 @@
+const { config } = require('../globals');
+
+function normalizeTag(value, seperator = config.tagSeperator) {
+    if (value instanceof Array) {
+        if (seperator) return value.join(seperator);
+        return value[0];
+    } else {
+        return value;
+    };
+}
+
+module.exports = normalizeTag;

--- a/src/utils/parseAlbum.js
+++ b/src/utils/parseAlbum.js
@@ -1,4 +1,5 @@
 const stripMarkup = require('./stripMarkup');
+const parseCredits = require('./parseCredits');
 
 const { config, tidalAlbumCoverSizes } = require('../globals');
 
@@ -26,7 +27,8 @@ function parseAlbum(album, additional = { }) {
         quality: album.audioQuality,
         modes: album.audioModes,
         qualityTypes: album.mediaMetadata?.tags,
-        credits: additional?.credits?.items,
+        credits: additional?.credits?.items ? parseCredits(additional.credits.items) : null,
+        trackCredits: additional?.trackCredits ? additional.trackCredits.map(i => ({ track: i.item, credits: parseCredits(i.credits) })) : null,
         review: additional?.review?.text ? {
             originalText: additional.review.text,
             text: stripMarkup(additional.review.text),

--- a/src/utils/parseConfig.js
+++ b/src/utils/parseConfig.js
@@ -4,7 +4,7 @@ const defaultConfig = require('../default.config.json');
 
 function parseConfig(configPath) {
     const jsonConfig = JSON.parse(fs.readFileSync(configPath));
-    const version = jsonConfig._version;
+    let version = jsonConfig._version;
 
     const config = {
         ...defaultConfig,
@@ -33,17 +33,21 @@ function parseConfig(configPath) {
             delete config.quality;
         }
         
-        config._version = 1;
+        version = 1;
     }
 
-    /*
     if (version === 1) {
-        // stuff
-        config._version = 2;
-    }
-    */
+        if (config.artistSeperator !== undefined) {
+            config.tagSeperator = config.artistSeperator;
+            delete config.artistSeperator;
+        }
 
-    if (config._version !== version) fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
+        version = 2;
+    }
+
+    config._version = version;
+
+    if (version !== jsonConfig._version) fs.writeFileSync(configPath, JSON.stringify(config, null, 4));
 
     return config;
 }

--- a/src/utils/parseCredits.js
+++ b/src/utils/parseCredits.js
@@ -1,0 +1,42 @@
+function parseCredits(credits) {
+    return Object.fromEntries(credits.map(credit => {
+        const type = credit.type.toLowerCase();
+        const contributors = credit.contributors;
+        
+        return [
+            // TODO: add missing types and maybe change keys
+            type === 'producer' ? 'producer' :
+            type === 'executive producer' ? 'executiveProducer' :
+            type === 'composer' ? 'composer' :
+            type === 'engineer' ? 'engineer' :
+            type === 'mastering engineer' ? 'masteringEngineer' :
+            type === 'mixing engineer' ? 'mixingEngineer' :
+            type === 'additional engineer' ? 'additionalEngineer' :
+            type === 'assistant engineer' ? 'assistantEngineer' :
+            type === 'recording engineer' ? 'recordingEngineer' :
+            type === 'associated performer' ? 'associatedPerformer' :
+            type === 'mixer' ? 'mixer' :
+            type === 'lyricist' ? 'lyricist' :
+            type === 'background vocal' ? 'backgroundVocal' :
+            type === 'vocal' ? 'vocal' :
+            type === 'guitar' ? 'guitar' :
+            type === 'bass' ? 'bass' :
+            type === 'piano' ? 'piano' :
+            type === 'drums' ? 'drums' :
+            type === 'horn' ? 'horn' :
+            type === 'strings' ? 'strings' :
+            type === 'whistles' ? 'whistle' :
+            type === 'keyboards' ? 'keyboard' :
+            type === 'banjo' ? 'banjo' :
+            type === 'remixer' ? 'remixer' :
+            type === 'primary artist' ? 'primaryArtist' :
+            type === 'photography' ? 'photographer' :
+            type === 'music publisher' ? 'publisher' :
+            type === 'record label' ? 'label' :
+            type,
+            contributors
+        ];
+    }))
+}
+
+module.exports = parseCredits;


### PR DESCRIPTION
adds various credit tags, still need to clean some stuff up probably

little rundown on changes:
* renamed `artistSeperator` to `tagSeperator` in config as it's now used for more than just artists tag, this also updates config to version 2
* made function to "normalize" tag values by adding the tag separator automatically
* add fuckton of credit tags, although a little bit random and probably incomplete/incorrect tag names
* extra api call on `getAlbum` to get track credits
* disable `useArtistsTag` in config (i literally enabled this by default days ago)
* adds `key` and `keyScale` to tracks

todo maybe:
* check how the url parameters in `/albums/x/items/credits` change responses

<img width="1013" height="411" alt="image" src="https://github.com/user-attachments/assets/6fe952a5-8f66-4eac-9141-ceb90fedd070" />
