### PR TITLE
Add Dolby Atmos download support

### DIFF
--- a/src/default.config.json
+++ b/src/default.config.json
@@ -6,6 +6,7 @@
     "videoFilename": "{{artist.name}} - {{title}}",
     "trackQuality": "MAX",
     "videoQuality": "MAX",
+    "useDolbyAtmos": false,
     "getLyrics": true,
     "syncedLyricsOnly": false,
     "plainLyricsOnly": false,

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ if (options.help || [
             options.trackQuality === 'low' ? 'HIGH' :
             options.trackQuality === 'high' ? 'LOSSLESS' :
             options.trackQuality === 'max' ? 'HI_RES_LOSSLESS' :
-            options.trackQuality;
+            options.trackQuality?.toUpperCase();
 
         const videoQuality =
             options.videoQuality === 'low' ? '480' :
@@ -198,6 +198,7 @@ if (options.help || [
             segmentWaitMin: config.segmentWaitMin,
             segmentWaitMax: config.segmentWaitMax,
             downloadLogPadding: config.downloadLogPadding,
+            useDolbyAtmos: config.useDolbyAtmos
         }).download();
     }
 

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -75,8 +75,8 @@ class Download {
             this.segmentUrls = this.manifest.segments;
             this.containerExtension = '.mp4';
             this.mediaExtension =
-                this.manifest.codecs === 'flac' ? '.flac' : // Used for lossless and hi-res lossless
-                this.manifest.codecs === 'ac4' ? '.ac4' : // Used for dolby atmos
+                this.manifest.codec === 'flac' ? '.flac' : // Used for lossless and hi-res lossless
+                this.manifest.codec === 'ac4' ? '.mp4' : // Used for dolby atmos
                 '.m4a'; // used for low quality // TODO: is it safe to assume AAC?
         } else if (this.details.isVideo) {
             const segmentManifests = this.manifest.mainManifests[0].segmentManifests;
@@ -188,15 +188,18 @@ class Download {
     }
 
     async createMedia() {
-        if (!this.embedMetadata || this.metadataEmbedder !== 'ffmpeg' || this.mediaExtension === '.ac4') {
+        if (this.manifest.codec === 'ac4') {
+            this.log(`Dolby AC-4 is not currently supported, keeping original stream!`, 'warn');
+            return fs.copyFileSync(this.getContainerPath(), this.getMediaPath());
+        }
+
+        if (!this.embedMetadata || this.metadataEmbedder !== 'ffmpeg') {
             // Extract from container
             this.log(`Creating ${this.mediaExtension} from ${this.containerExtension} container...`);
             await extractContainer(this.getContainerPath(), this.getMediaPath());
         }
         
         if (this.embedMetadata) {
-            if (this.mediaExtension === '.ac4') return this.log(`Embedding metadata to Dolby AC-4 is not currently possible!`, 'warn');
-
             // Embed metadata
             if (this.metadataEmbedder === 'kid3') {
                 // Embed via kid3
@@ -217,7 +220,7 @@ class Download {
     }
 
     getContainerPath() {
-        return path.join(this.directory, `${this.mediaFilename}${this.containerExtension}`);
+        return path.join(this.directory, `${this.mediaFilename}.original${this.containerExtension}`);
     }
 
     getCoverPath() {

--- a/src/utils/getPlaybackInfo.js
+++ b/src/utils/getPlaybackInfo.js
@@ -1,11 +1,12 @@
 const tidalApi = require('./tidalApi');
 
-function getPlaybackInfo(id, type = 'track', quality = 'HI_RES_LOSSLESS', playbackMode = 'STREAM', assetPresentation = 'FULL') {
+function getPlaybackInfo(id, type = 'track', quality = 'HI_RES_LOSSLESS', immersiveAudio = false, playbackMode = 'STREAM', assetPresentation = 'FULL') {
     const isVideo = type === 'video' ? true : false;
 
     return tidalApi('privatev1', `/${type === 'video' ? 'videos' : 'tracks'}/${id}/playbackinfo`, {
         query: {
             ...(isVideo ? { videoquality: quality } : { audioquality: quality }),
+            immersiveaudio: immersiveAudio,
             playbackmode: playbackMode,
             assetpresentation: assetPresentation
         }

--- a/src/utils/parseManifest.js
+++ b/src/utils/parseManifest.js
@@ -4,7 +4,7 @@ async function parseManifest(manifest, manifestType) {
             contentType: null,
             mimeType: null,
             segmentAlignment: null,
-            codecs: null,
+            codec: null,
             bandwidth: null,
             audioSamplingRate: null,
             timescale: null,
@@ -16,7 +16,7 @@ async function parseManifest(manifest, manifestType) {
         };
 
         // TODO: a little less jank perhaps
-        parsedManifest.codecs = manifest.match(/(?:<|\s)codecs="(.*?)"/)?.[1];
+        parsedManifest.codec = manifest.match(/(?:<|\s)codecs="(.*?)"/)?.[1];
         parsedManifest.audioSamplingRate = parseInt(manifest.match(/(?:<|\s)audioSamplingRate="(.*?)"/)?.[1]);
         parsedManifest.initialization = manifest.match(/(?:<|\s)initialization="(.*?)"/)?.[1];
         parsedManifest.media = manifest.match(/(?:<|\s)media="(.*?)"/)?.[1];
@@ -38,7 +38,7 @@ async function parseManifest(manifest, manifestType) {
             const segmentManifests = Array.from(mainManifest.matchAll(/#EXT-X-STREAM-INF:BANDWIDTH=(.*?),AVERAGE-BANDWIDTH=(.*?),CODECS="(.*?)",RESOLUTION=(.*?)\n(.*?)\n/g)).map(i => ({
                 bandwidth: i[1],
                 averageBandwidth: i[2],
-                codecs: i[3],
+                codec: i[3],
                 resolution: i[4],
                 url: i[5],
                 raw: null,
@@ -67,7 +67,7 @@ async function parseManifest(manifest, manifestType) {
         
         return {
             mimeType: manifestJson.mimeType,
-            codecs: manifestJson.codecs,
+            codec: manifestJson.codecs,
             encryptionType: manifestJson.encryptionType,
             segments: manifestJson.urls
         }
@@ -75,14 +75,14 @@ async function parseManifest(manifest, manifestType) {
         const parsedManifest = {
             bandwidth: null,
             averageBandwidth: null,
-            codecs: null,
+            codec: null,
             raw: null,
             segments: []
         };
 
         parsedManifest.bandwidth = parseInt(manifest.match(/BANDWIDTH=\d+/))?.[1];
         parsedManifest.averageBandwidth = parseInt(manifest.match(/AVERAGE-BANDWIDTH=\d+/))?.[1];
-        parsedManifest.codecs = manifest.match(/CODECS="(.*?)"/)?.[1]?.toLowerCase();
+        parsedManifest.codec = manifest.match(/CODECS="(.*?)"/)?.[1]?.toLowerCase();
         parsedManifest.raw = Buffer.from(manifest.match(/data:application\/vnd\.apple\.mpegurl;base64,(.*)/)?.[1], 'base64').toString();
         parsedManifest.segments = [parsedManifest.raw.match(/#EXT-X-MAP:URI="(.*?)"/)[1], ...Array.from(parsedManifest.raw.matchAll(/#EXTINF:(.*?),\n(.*?)\n/g)).map(i => i[2])];
 


### PR DESCRIPTION
i dont think this will be possible using the current authentication method, but could be nice to implement
## notes:
* this seems to require a token generated for a phone (or something that supports dolby atmos i guess), which means it wont work with the regular android tv authentication method
* supplying a `immersiveaudio=true` query parameter to `tracks/<id>/playbackinfo` can give you the playback info for a ac4 stream wrapped in a mp4 container
* the manifest type used is `application/vnd.tidal.bts`, it seems to be very simple and not much has to be changed
* ffmpeg does not currently support decoding/encoding ac4 yet