### PR TITLE
Add `--update` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For a list of available commands, run `tidalwave --help`
 * `--search:artist <query>`, `-s:a`: Downloads top search result for artists
 * `--search:playlist <query>`, `-s:p`: Downloads top search result for playlists
 * `--url <url>`, `-u`: Download from URL
+* `--update <path>`: Update an existing file with metadata from TIDAL, without downloading
 * `--track-quality <low|high|max>`, `-tq`: Sets track download quality, defaults to config `trackQuality`
 * `--video-quality <low|high|max|<height>>`, `-vq`: Sets video download quality, defaults to config `videoQuality`
 * `--metadata <yes|no>`, `-md`: Enables or disables all metadata embedding, defaults to config `embedMetadata`

--- a/src/globals.js
+++ b/src/globals.js
@@ -43,6 +43,7 @@ module.exports = {
         { name: 'search:artist', shortName: 's:a', description: 'Downloads top search result for artists', valueDescription: 'query' },
         { name: 'search:playlist', shortName: 's:p', description: 'Downloads top search result for playlists', valueDescription: 'query' },
         { name: 'url', shortName: 'u', description: 'Download from URL', valueDescription: 'url' },
+        { name: 'update', description: 'Update an existing file with metadata from TIDAL, without downloading', valueDescription: 'path' },
         { name: 'track-quality', shortName: 'tq', aliases: ['quality'], shortAliases: ['q'], description: 'Sets track download quality', valueDescription: 'low|high|max' },
         { name: 'video-quality', shortName: 'vq', description: 'Sets video download quality', valueDescription: 'low|high|max|<height>' },
         { name: 'metadata', shortName: 'md', type: 'bool', description: 'Enables or disables all metadata embedding', valueDescription: 'yes|no' },

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ if (options.help || [
                 mediaFilename: updatePathFilename,
                 coverFilename: updatePathFilename,
 
-                // metadataEmbedder: config.metadataEmbedder,
+                metadataEmbedder: config.metadataEmbedder,
                 keepCoverFile: config.coverFilename ? true : false,
                 getCover: options.cover,
                 getLyrics: options.lyrics,

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const options = {
         ...args.getAll('search:playlist').map(query => ({ type: 'playlist', query })),
     ],
     urls: args.getAll('url'),
+    updates: args.getAll('update'),
     trackQuality: (args.get('track-quality') ?? config.trackQuality)?.toLowerCase(),
     videoQuality: (args.get('video-quality') ?? config.videoQuality)?.toLowerCase(),
     metadata: args.get('metadata') ?? config.embedMetadata,
@@ -117,7 +118,9 @@ if (options.help || [
             .map(([type, count]) => `${Logger.applyColor({ bold: true }, count)} ${type}${count !== 1 ? 's' : ''}`)
             .join(', ')}...`);
 
-    for (const item of queue) {
+    for (let itemIndex = 0; itemIndex < queue.length; itemIndex++) {
+        const item = queue[itemIndex];
+
         const details = {
             track: item.track,
             album: item.album,
@@ -181,34 +184,59 @@ if (options.help || [
             options.videoQuality === 'high' ? '720' :
             options.videoQuality === 'max' ? null :
             options.videoQuality;
+        
+            
+        if (options.updates[itemIndex]) {
+            const updatePath = path.resolve(execDir, options.updates[itemIndex]);
+            const updatePathDirectory = path.dirname(updatePath);
+            const updatePathExtension = path.extname(updatePath);
+            const updatePathFilename = path.basename(updatePath, updatePathExtension);
 
-        await new Download({
-            details,
-            logger,
-            trackQuality,
-            videoQuality,
-            directory,
-            mediaFilename,
-            coverFilename: config.coverFilename ? formatPath(config.coverFilename, details) : mediaFilename,
-            overwriteExisting: options.overwrite,
-            embedMetadata: options.metadata,
-            metadataEmbedder: config.metadataEmbedder,
-            keepCoverFile: config.coverFilename ? true : false,
-            getCover: options.cover,
-            getLyrics: options.lyrics,
-            syncedLyricsOnly: config.syncedLyricsOnly,
-            plainLyricsOnly: config.plainLyricsOnly,
-            externalLyrics: config.externalLyrics,
-            useArtistsTag: config.useArtistsTag,
-            artistTagSeparator: config.artistTagSeparator,
-            roleTagSeparator: config.roleTagSeparator,
-            customMetadata: config.customMetadata,
-            keepContainerFile: config.debug ? true : false,
-            segmentWaitMin: config.segmentWaitMin,
-            segmentWaitMax: config.segmentWaitMax,
-            downloadLogPadding: config.downloadLogPadding,
-            useDolbyAtmos: config.useDolbyAtmos
-        }).download();
+            const download = new Download({
+                details,
+                logger,
+                directory: updatePathDirectory,
+                mediaFilename: updatePathFilename,
+                originalExtension: updatePathExtension,
+                mediaExtension: updatePathExtension,
+                // TODO: add some of these configs
+                getCover: false,
+                getLyrics: false
+            });
+
+            await download.getMetadata(); // Get metadata
+            fs.renameSync(updatePath, download.getOriginalPath()); // Rename original file temporarily
+            await download.createMedia(); // Create new file
+            fs.unlinkSync(download.getOriginalPath()); // Delete original file
+        } else {
+            await new Download({
+                details,
+                logger,
+                directory,
+                mediaFilename,
+                trackQuality,
+                videoQuality,
+                coverFilename: config.coverFilename ? formatPath(config.coverFilename, details) : mediaFilename,
+                overwriteExisting: options.overwrite,
+                embedMetadata: options.metadata,
+                metadataEmbedder: config.metadataEmbedder,
+                keepCoverFile: config.coverFilename ? true : false,
+                getCover: options.cover,
+                getLyrics: options.lyrics,
+                syncedLyricsOnly: config.syncedLyricsOnly,
+                plainLyricsOnly: config.plainLyricsOnly,
+                externalLyrics: config.externalLyrics,
+                useArtistsTag: config.useArtistsTag,
+                artistTagSeparator: config.artistTagSeparator,
+                roleTagSeparator: config.roleTagSeparator,
+                customMetadata: config.customMetadata,
+                keepOriginalFile: config.debug ? true : false,
+                segmentWaitMin: config.segmentWaitMin,
+                segmentWaitMax: config.segmentWaitMax,
+                downloadLogPadding: config.downloadLogPadding,
+                useDolbyAtmos: config.useDolbyAtmos
+            }).download();
+        }
     }
 
     // logger.emptyLine();

--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,6 @@ if (options.help || [
             options.videoQuality === 'max' ? null :
             options.videoQuality;
         
-            
         if (options.updates[itemIndex]) {
             const updatePath = path.resolve(execDir, options.updates[itemIndex]);
             const updatePathDirectory = path.dirname(updatePath);
@@ -197,11 +196,23 @@ if (options.help || [
                 logger,
                 directory: updatePathDirectory,
                 mediaFilename: updatePathFilename,
+                coverFilename: updatePathFilename,
+
+                // metadataEmbedder: config.metadataEmbedder,
+                keepCoverFile: config.coverFilename ? true : false,
+                getCover: options.cover,
+                getLyrics: options.lyrics,
+                syncedLyricsOnly: config.syncedLyricsOnly,
+                plainLyricsOnly: config.plainLyricsOnly,
+                externalLyrics: config.externalLyrics,
+                useArtistsTag: config.useArtistsTag,
+                artistTagSeparator: config.artistTagSeparator,
+                roleTagSeparator: config.roleTagSeparator,
+                customMetadata: config.customMetadata,
+                downloadLogPadding: config.downloadLogPadding,
+
                 originalExtension: updatePathExtension,
                 mediaExtension: updatePathExtension,
-                // TODO: add some of these configs
-                getCover: false,
-                getLyrics: false
             });
 
             await download.getMetadata(); // Get metadata

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -62,7 +62,7 @@ class Download {
         await this.downloadSegments(); // Download segments
         if (this.embedMetadata) await this.getMetadata(); // Get metadata
         await this.createMedia(); // Create output
-        if (!this.keepContainerFile) fs.unlinkSync(this.getOriginalPath()); // Delete container file
+        if (!this.keepOriginalFile) fs.unlinkSync(this.getOriginalPath()); // Delete container file
         if (!this.keepCoverFile && fs.existsSync(this.getCoverPath())) fs.unlinkSync(this.getCoverPath()); // Delete cover file
 
         this.log(`Completed (${Math.floor((Date.now() - startDate) / 1000)}s)`);

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -204,13 +204,13 @@ class Download {
 
     async createMedia() {
         if (this.manifest?.codec === 'ac4') {
-            this.log(`Dolby AC-4 is not currently supported, keeping original stream!`, 'warn');
+            this.log('Dolby AC-4 is not currently supported, keeping original stream!', 'warn');
             return fs.copyFileSync(this.getOriginalPath(), this.getMediaPath());
         }
 
         if (!this.embedMetadata || this.metadataEmbedder !== 'ffmpeg') {
             // Extract from container
-            this.log(`Creating ${this.mediaExtension} from ${this.originalExtension} container...`);
+            this.log(`Converting to ${this.mediaExtension}...`);
             await extractContainer(this.getOriginalPath(), this.getMediaPath());
         }
         
@@ -224,7 +224,7 @@ class Download {
                 });
             } else {
                 // Extract and embed via FFmpeg
-                this.log(`Creating ${this.mediaExtension} with metadata from ${this.originalExtension} container...`);
+                this.log(`Converting to ${this.mediaExtension} with metadata...`);
                 await createMedia(this.getOriginalPath(), this.getMediaPath(), this.metadata, fs.existsSync(this.getCoverPath()) ? this.getCoverPath() : undefined, this.details.isVideo ? 2 : 1);
             }
         }

--- a/src/utils/createMedia.js
+++ b/src/utils/createMedia.js
@@ -2,7 +2,7 @@ const spawn = require('./spawn');
 
 const { config } = require('../globals');
 
-function createMedia(inputPath, outputPath, coverPath, metadata, streams = 1) {
+function createMedia(inputPath, outputPath, metadata, coverPath, streams = 1) {
     return spawn(config.ffmpegPath, [
         '-i', inputPath,
         ...(coverPath ? [


### PR DESCRIPTION
this adds a `--update` arg to update an existing track/videos metadata without actually downloading the entire thing, it is to be used with another arg (eg. `--url`, `--track`, `--search`) to actually identify the track/video
this can be useful to add more metadata to a track that wasnt downloaded from tidalwave

examples:
single:  `tidalwave -s:t "bedroom community glass beach" --update "~/Music/bedroom community.flac"`
multiple: `tidalwave -s:t "ring ring ring tyler the creator" --update "~/Music/Ring Ring Ring.flac" -s:t "sugar on my tongue" --update "~/Music/Sugar on My Tongue.flac"`

todo maybe:
* sperate certain options in `Download` class, depending on if related to downloading, metadata, etc