### PR TITLE
Implement mixes

### DIFF
--- a/src/default.config.json
+++ b/src/default.config.json
@@ -25,6 +25,8 @@
     "videoQuality": "MAX",
     "playlistCoverFilename": "{{playlist.title}}",
     "playlistFileFilename": "{{playlist.title}}",
+    "mixCoverFilename": "{{mix.title}} - {{mix.subTitle}}",
+    "mixFileFilename": "{{mix.title}} - {{mix.subTitle}}",
     "useDolbyAtmos": false,
     "getLyrics": true,
     "syncedLyricsOnly": false,
@@ -40,6 +42,7 @@
     "trackCoverSize": "1280",
     "videoCoverSize": "1280x720",
     "playlistCoverSize": "ORIGINAL",
+    "mixCoverSize": "LARGE",
     "customMetadata": [
         ["comment", "Downloaded from TIDAL: {{url}}"],
         ["source", "TIDAL"],

--- a/src/default.config.json
+++ b/src/default.config.json
@@ -12,7 +12,12 @@
         },
         "playlist": {
             "directory": "./Downloads/Playlists/{{playlist.title}}",
-            "filename": "{{playlistItemNum}} - {{artist.name}} - {{title}}",
+            "filename": "{{itemNum}} - {{artist.name}} - {{title}}",
+            "coverFilename": null
+        },
+        "mix": {
+            "directory": "./Downloads/Mixes/{{mix.title}} - {{mix.subTitle}}",
+            "filename": "{{itemNum}} - {{artist.name}} - {{title}}",
             "coverFilename": null
         }
     },

--- a/src/globals.js
+++ b/src/globals.js
@@ -87,6 +87,11 @@ module.exports = {
         '1280': '1280x1280',
         'ORIGINAL': 'origin'
     },
+    tidalMixImageSizes: {
+        'SMALL': 'SMALL',
+        'MEDIUM': 'MEDIUM',
+        'LARGE': 'LARGE'
+    },
     tidalCredits: [
         // NOTE: found from searching various albums and tracks, theres definitely more
 

--- a/src/globals.js
+++ b/src/globals.js
@@ -36,6 +36,7 @@ module.exports = {
         { name: 'video', shortName: 'v', description: 'Download a video ID', valueDescription: 'video-id' },
         { name: 'artist', shortName: 'a', type: 'int', description: 'Download an artist ID\'s discography', valueDescription: 'artist-id' },
         { name: 'playlist', shortName: 'p', description: 'Download all items from a playlist UUID', valueDescription: 'playlist-uuid' },
+        { name: 'mix', shortName: 'x', description: 'Download all items from a mix ID', valueDescription: 'mix-id' },
         { name: 'search', shortName: 's', description: 'Download top search', valueDescription: 'query' },
         { name: 'search:track', shortName: 's:t', description: 'Download top search for a track', valueDescription: 'query' },
         { name: 'search:album', shortName: 's:m', description: 'Download top search for a album', valueDescription: 'query' },

--- a/src/index.js
+++ b/src/index.js
@@ -159,8 +159,12 @@ if (options.help || [
             queueNum: itemIndex + 1,
             itemNum: item.itemIndex + 1,
             playlistCover: item.playlist ? item.playlist.images[config.playlistCoverSize?.toUpperCase()] || item.playlist.images['ORIGINAL'] : null,
+            mixCover: item.mix ? item.mix.images[config.mixCoverSize?.toUpperCase()] || item.mix.images['LARGE'] : null,
+            mixDetailCover: item.mix ? item.mix.detailImages[config.mixCoverSize?.toUpperCase()] || item.mix.images['LARGE'] : null, // not currently used
             isTrack: item.track ? true : false,
             isVideo: item.video ? true : false,
+            isPlaylist: item.playlist ? true : false,
+            isMix: item.mix ? true : false,
 
             // Generic details
             type:
@@ -258,8 +262,8 @@ if (options.help || [
                 directory,
                 mediaFilename,
                 coverFilename,
-                playlistCoverFilename: config.playlistCoverFilename && formatPath(config.playlistCoverFilename, details),
-                playlistFileFilename: config.playlistFileFilename && formatPath(config.playlistFileFilename, details),
+                playlistCoverFilename: (config.playlistCoverFilename && formatPath(config.playlistCoverFilename, details)) || (config.mixCoverFilename && formatPath(config.mixCoverFilename, details)),
+                playlistFileFilename: (config.playlistFileFilename && formatPath(config.playlistFileFilename, details)) || (config.mixFileFilename && formatPath(config.mixFileFilename, details)),
                 trackQuality: tidalTrackQualities[options.trackQuality] === undefined ? options.trackQuality : tidalTrackQualities[options.trackQuality],
                 videoQuality: tidalVideoQualities[options.videoQuality] === undefined ? options.videoQuality : tidalVideoQualities[options.videoQuality],
                 overwriteExisting: options.overwrite,

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ if (options.help || [
     ...options.videos,
     ...options.artists,
     ...options.playlists,
+    ...options.mixes,
     ...options.searches,
     ...options.urls
 ].length === 0) showHelp();

--- a/src/index.js
+++ b/src/index.js
@@ -245,9 +245,9 @@ if (options.help || [
             const typeOptions = {
                 ...config.defaultTypeOptions,
                 ...config.typeOptions[
-                    details.video ? 'video' :
-                    details.playlist ? 'playlist' :
-                    details.mix ? 'mix' :
+                    details.isVideo ? 'video' :
+                    details.isPlaylist ? 'playlist' :
+                    details.isMix ? 'mix' :
                     'album' // NOTE: we dont know whether a entire album is in the queue or just 1 track
                 ],
             };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const getArtist = require('./utils/getArtist');
 const getTrack = require('./utils/getTrack');
 const getVideo = require('./utils/getVideo');
 const getPlaylist = require('./utils/getPlaylist');
+const getMix = require('./utils/getMix');
 const search = require('./utils/search');
 const Args = require('./utils/Args');
 const formatPath = require('./utils/formatPath');
@@ -35,6 +36,7 @@ const options = {
     videos: args.getAll('video'),
     artists: args.getAll('artist'),
     playlists: args.getAll('playlist'),
+    mixes: args.getAll('mix'),
     searches: [
         ...args.getAll('search').map(query => ({ type: null, query })),
         ...args.getAll('search:track').map(query => ({ type: 'track', query })),
@@ -84,6 +86,7 @@ if (options.help || [
     for (const videoId of options.videos) await addVideo(videoId); // Videos
     for (const artistId of options.artists) await addArtist(artistId); // Artists
     for (const playlistUuid of options.playlists) await addPlaylist(playlistUuid); // Playlists
+    for (const mixId of options.mixes) await addMix(mixId); // Mixes
 
     // Searches
     for (const { type, query } of options.searches) {
@@ -107,17 +110,18 @@ if (options.help || [
 
     // URLS
     for (const url of options.urls) {
-        const match = url.match(/tidal\.com.*\/(track|album|video|artist|playlist)\/([0-9a-f-]+)/i);
+        const match = url.match(/tidal\.com.*\/(track|album|video|artist|playlist|mix)\/([0-9a-f-]+)/i);
         if (match) {
             const type = match[1].toLowerCase();
-            const id = parseInt(match[2], 10);
-            const uuid = match[2];
+            const id = match[2];
+            const idInt = parseInt(id, 10);
             
-            if (type === 'track') await addTrack(id); else
-            if (type === 'album') await addAlbum(id); else
-            if (type === 'video') await addVideo(id); else
-            if (type === 'artist') await addArtist(id); else
-            if (type === 'playlist') await addPlaylist(uuid); else
+            if (type === 'track') await addTrack(idInt); else
+            if (type === 'album') await addAlbum(idInt); else
+            if (type === 'video') await addVideo(idInt); else
+            if (type === 'artist') await addArtist(idInt); else
+            if (type === 'playlist') await addPlaylist(id); else
+            if (type === 'mix') await addMix(id); else
             logger.error(`Unknown type "${Logger.applyColor({ bold: true }, type)}"`, true, true); // NOTE: not possible with current regex
         } else {
             logger.error(`Couldn't determine URL "${Logger.applyColor({ bold: true }, url)}"`, true, true);
@@ -145,13 +149,14 @@ if (options.help || [
             artists: item.artists,
             albumArtists: item.albumArtists,
             playlist: item.playlist,
-            trackIndex: item.trackIndex, // used for playlists
+            mix: item.mix,
+            itemIndex: item.itemIndex, // used for playlists and mixes
             
             artist: item.artists?.[0],
             albumArtist: item.albumArtists?.[0],
             trackNumberPadded: item.track?.trackNumber?.toString().padStart(2, '0'), // TODO: maybe remove this and add a padding function in formatString?
             queueNum: itemIndex + 1,
-            playlistItemNum: item.trackIndex + 1,
+            itemNum: item.itemIndex + 1,
             playlistCover: item.playlist ? item.playlist.images[config.playlistCoverSize?.toUpperCase()] || item.playlist.images['ORIGINAL'] : null,
             isTrack: item.track ? true : false,
             isVideo: item.video ? true : false,
@@ -235,8 +240,9 @@ if (options.help || [
             const typeOptions = {
                 ...config.defaultTypeOptions,
                 ...config.typeOptions[
-                    details.playlist ? 'playlist' :
                     details.video ? 'video' :
+                    details.playlist ? 'playlist' :
+                    details.mix ? 'mix' :
                     'album' // NOTE: we dont know whether a entire album is in the queue or just 1 track
                 ],
             };
@@ -394,8 +400,8 @@ if (options.help || [
             const playlist = await getPlaylist(playlistUuid);
 
             // We don't need to fetch the track here, everything needed seems to be included
-            for (let trackIndex = 0; trackIndex < playlist.tracks.length; trackIndex++) {
-                const track = playlist.tracks[trackIndex];
+            for (let itemIndex = 0; itemIndex < playlist.tracks.length; itemIndex++) {
+                const track = playlist.tracks[itemIndex];
 
                 const artists = [];
                 const albumArtists = [];
@@ -410,13 +416,44 @@ if (options.help || [
                     artists,
                     albumArtists,
                     playlist,
-                    trackIndex
+                    itemIndex
                 });
             }
 
             logger.info(`Found playlist: ${Logger.applyColor({ bold: true }, `${playlist.title} - ${playlist.trackCount} tracks`)} (${playlist.uuid})`, true, true);
         } catch (err) {
             logger.error(`Could not find playlist UUID: ${Logger.applyColor({ bold: true }, playlistUuid)}`, true, true);
+        }
+    }
+
+    async function addMix(mixId) {
+        try {
+            const mix = await getMix(mixId);
+
+            for (let itemIndex = 0; itemIndex < mix.tracks.length; itemIndex++) {
+                const partialTrack = mix.tracks[itemIndex];
+                const track = await findTrack(partialTrack.id, partialTrack);
+
+                const artists = [];
+                const albumArtists = [];
+
+                const album = await findAlbum(track.album.id, track.album);
+                for (const artist of track.artists) artists.push(await findArtist(artist.id, artist));
+                for (const artist of album.artists) albumArtists.push(await findArtist(artist.id, artist));
+
+                queue.push({
+                    track,
+                    album,
+                    artists,
+                    albumArtists,
+                    mix,
+                    itemIndex
+                });
+            }
+
+            logger.info(`Found mix: ${Logger.applyColor({ bold: true }, `${mix.title} - ${mix.subTitle}`)} (${mix.id})`, true, true);
+        } catch (err) {
+            logger.error(`Could not find mix ID: ${Logger.applyColor({ bold: true }, mixId)}`, true, true);
         }
     }
 

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -61,7 +61,7 @@ class Download {
         fs.mkdirSync(this.directory, { recursive: true }); // Create directory
         await this.getSegments(); // Get segment URL's
         if (fs.existsSync(this.getMediaPath()) && !this.overwriteExisting) return this.log('Already downloaded!'); // Check if already downloaded
-        if (this.details.playlist || this.details.mix) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
+        if (this.details.isPlaylist || this.details.isMix) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
         await this.downloadSegments(); // Download segments
         if (this.embedMetadata) await this.getMetadata(); // Get metadata
         await this.createMedia(); // Create output

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -61,7 +61,7 @@ class Download {
         fs.mkdirSync(this.directory, { recursive: true }); // Create directory
         await this.getSegments(); // Get segment URL's
         if (fs.existsSync(this.getMediaPath()) && !this.overwriteExisting) return this.log('Already downloaded!'); // Check if already downloaded
-        if (this.details.playlist) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
+        if (this.details.playlist || this.details.mix) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
         await this.downloadSegments(); // Download segments
         if (this.embedMetadata) await this.getMetadata(); // Get metadata
         await this.createMedia(); // Create output
@@ -73,17 +73,18 @@ class Download {
 
     async createPlaylist() {
         // Download playlist cover
+        // TODO: make cleaner
         if (this.getCover && this.playlistCoverFilename && !fs.existsSync(this.getPlaylistCoverPath())) {
-            this.log('Downloading playlist cover...');
-            await fetch(this.details.playlistCover).then(async res => {
+            this.log(`Downloading ${this.details.isMix ? 'mix' : 'playlist'} cover...`);
+            await fetch(this.details.isMix ? this.details.mixCover : this.details.playlistCover).then(async res => {
                 if (res.status !== 200) throw new Error(`Got status code ${res.status}`);
                 const coverBuffer = Buffer.from(await res.arrayBuffer());
                 fs.writeFileSync(this.getPlaylistCoverPath(), coverBuffer);
             }).catch(err => {
-                this.log(`Failed to download playlist cover: ${err.message}`, 'error');
+                this.log(`Failed to download ${this.details.isMix ? 'mix' : 'playlist'} cover: ${err.message}`, 'error');
             });
         } else {
-            this.log('Playlist cover already downladed');
+            this.log(`${this.details.isMix ? 'Mix' : 'Playlist'} cover already downladed`);
         }
 
         // Create playlist .m3u8 file

--- a/src/utils/Download.js
+++ b/src/utils/Download.js
@@ -59,9 +59,9 @@ class Download {
         this.logger.lastLog = '';
 
         fs.mkdirSync(this.directory, { recursive: true }); // Create directory
-        if (this.details.playlist) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
         await this.getSegments(); // Get segment URL's
         if (fs.existsSync(this.getMediaPath()) && !this.overwriteExisting) return this.log('Already downloaded!'); // Check if already downloaded
+        if (this.details.playlist) await this.createPlaylist(); // Create playlist info (.m3u8 and cover)
         await this.downloadSegments(); // Download segments
         if (this.embedMetadata) await this.getMetadata(); // Get metadata
         await this.createMedia(); // Create output

--- a/src/utils/getMix.js
+++ b/src/utils/getMix.js
@@ -1,0 +1,10 @@
+const tidalApi = require('./tidalApi');
+const parseMix = require('./parseMix');
+
+async function getMix(mixId) {
+    return tidalApi('privatev1', '/pages/mix', { query: { mixId } }).then(({ json }) => parseMix(json.rows[0].modules[0].mix, {
+        items: json.rows[1].modules[0].pagedList.items
+    }));
+}
+
+module.exports = getMix;

--- a/src/utils/parseMix.js
+++ b/src/utils/parseMix.js
@@ -1,0 +1,15 @@
+const parseTrack = require("./parseTrack");
+
+function parseMix(mix, additional = { }) {
+    return {
+        id: mix.id,
+        title: mix.title,
+        subTitle: mix.subTitle,
+        shortSubTitle: mix.shortSubtitle,
+        description: mix.description,
+        // images: mix.images, // TODO: add images (no text) and detailImages (with text)
+        tracks: additional?.items.map(item => parseTrack(item))
+    };
+}
+
+module.exports = parseMix;

--- a/src/utils/parseMix.js
+++ b/src/utils/parseMix.js
@@ -7,7 +7,8 @@ function parseMix(mix, additional = { }) {
         subTitle: mix.subTitle,
         shortSubTitle: mix.shortSubtitle,
         description: mix.description,
-        // images: mix.images, // TODO: add images (no text) and detailImages (with text)
+        images: Object.fromEntries(Object.entries(mix.images).map(([key, value]) => [key, value.url])),
+        detailImages: Object.fromEntries(Object.entries(mix.detailImages).map(([key, value]) => [key, value.url])),
         tracks: additional?.items.map(item => parseTrack(item))
     };
 }


### PR DESCRIPTION
adds `--mix`/`-x` argument to download mixes, uses its own download path similar to playlists

notes: 
* renamed details variables `trackIndex` and `playlistTrackNum` to `itemIndex` and `itemNum`, so this will break paths in existing configs